### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "installer-name": "silverstripe-batchwrite"
   },
   "require": {
-    "silverstripe/framework": ">=3.0",
-    "silverstripe/cms": ">=3.0"
+    "silverstripe/framework": "^3.0",
+    "silverstripe/cms": "^3.0"
   }
 }


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.

This will also ensure that addons.silverstripe.org correctly reports which modules
work with SS4.